### PR TITLE
Add description attribute to commands

### DIFF
--- a/lib/commander.ex
+++ b/lib/commander.ex
@@ -86,6 +86,7 @@ defmodule Coxir.Commander do
           __MODULE__,
           unquote(name),
           @space,
+          @description,
           &1
         }
       )
@@ -140,7 +141,7 @@ defmodule Coxir.Commander do
     [do: block]
   end
 
-  defp clause({from, name, space, arity}) do
+  defp clause({from, name, space, _description, arity}) do
     # Path
     path = space
     |> case do

--- a/lib/commander/helpers.ex
+++ b/lib/commander/helpers.ex
@@ -5,6 +5,7 @@ defmodule Coxir.Commander.Helpers do
       @space :""
       @permit :any
       @channel :any
+      @description :""
     end
   end
 


### PR DESCRIPTION
Adds a description attribute to commands. This is just a simple field that can be filed with a String.

Useful in case you want to make a `help` command programmatically.

Output:
```Elixir
  @description "The help command"
  command help() do
    IO.inspect @commands
    {_, _, _, desc, _} = @commands
    |> Enum.filter(fn {_, :help, _, _, _} -> true
        _ -> false
    end)
    |> List.first()

    Message.reply(message, desc)
  end
```
will output something like this
[Discord](https://cdn.discordapp.com/attachments/411615726739390464/485806171098185728/unknown.png)
[Console](https://cdn.discordapp.com/attachments/411615726739390464/485806255223472139/unknown.png)


*There is probably a much cleaner way of writing that code block there :stuck_out_tongue:*